### PR TITLE
Fix installation error: relax R version dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ LazyData: false
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Depends: 
-    R (>= 4.5)
+    R (>= 4.0)
 Imports: 
     colorRamps,
     dplyr,


### PR DESCRIPTION
The current dependency R (>= 4.5) prevents installation on the latest stable R version (4.4.x). Relaxing this requirement allows users to install the package on current standard environments.